### PR TITLE
docs: fix typos and next/previous link position inconsistency

### DIFF
--- a/docs/html/parser.html
+++ b/docs/html/parser.html
@@ -50,7 +50,7 @@
 			<li>Three functions for looking up certain data.</li>
 			<li>The amount of <spec>spawns</spec>.</li>
 			<li>The list of processed <spec>expression macros</spec>.</li>
-			<li>Other minor functionality values, such as weather "temporary object fields" have been used already.</li>
+			<li>Other minor functionality values, such as whether "temporary object fields" have been used already.</li>
 		</ul>
 		</p>
 	</body>

--- a/docs/html/state-extern.html
+++ b/docs/html/state-extern.html
@@ -24,7 +24,7 @@
 		<h2>10.7. External Modules</h2>
 		</span>
 		<p>
-		Using the <mono>#module</mono> directive makes all code within the directive block part of the specified module, including states. If a state is part of an external module, then its blocks must specific rules, depending on the game version. For <spec><em>Crash 1</em></spec>, all blocks must be within the same module, and cannot be in the main default module. For <spec><em>Crash 2</em></spec> onwards, the blocks must be either in the main default module, or within the currently selected module.
+		Using the <mono>#module</mono> directive makes all code within the directive block part of the specified module, including states. If a state is part of an external module, then its blocks must follow specific rules, depending on the game version. For <spec><em>Crash 1</em></spec>, all blocks must be within the same module, and cannot be in the main default module. For <spec><em>Crash 2</em></spec> onwards, the blocks must be either in the main default module, or within the currently selected module.
 		</p>
 	</body>
 </html>

--- a/docs/html/state-flags.html
+++ b/docs/html/state-flags.html
@@ -24,7 +24,7 @@
 		<h2>10.5. State Change Flags</h2>
 		</span>
 		<p>
-		States can define sets of flags to control what states an object can change to from. This is particularly useful for advanced error handling, but has a few other specific use cases. The two fields for these flags are <mono>stateflag</mono> and <mono>statusc</mono>.
+		States can define sets of flags to control what states an object can change to and from. This is particularly useful for advanced error handling, but has a few other specific use cases. The two fields for these flags are <mono>stateflag</mono> and <mono>statusc</mono>.
 		</p>
 		<p>
 		A state's <mono>stateflag</mono> and <mono>statusc</mono> values can be set in the state statements, like so:
@@ -45,7 +45,7 @@ state SecondState {
 		If these statements aren't presented, default values are used instead. The default <mono>stateflag</mono> is <mono>0x1</mono> and the default <mono>statusc</mono> is <mono>0x2</mono>. When an object's state is set (including when it spawns), the state's flags are copied onto the object's fields with the same names. An object can then modify these at will.
 		</p>
 		<p>
-		Whether an object's state can be changed into the target state is determined by whether the object's <mono>statusc</mono> has <em>any</em> of the flags in the state's <mono>stateflag</mono>, that is, whether the operation <mono>object->statusc & state->stateflag</mono> return zero or not. If the result is true, then no state change is performed and the object continues to run as if nothing had happened. Certain scenarios imply some extra flags, for example certain events will check using the operation <mono>(object->statusc | 0x1002) & state->stateflag</mono> instead. <unknown>TBD</unknown>
+		Whether an object's state can be changed into the target state is determined by whether the object's <mono>statusc</mono> has <em>any</em> of the flags in the state's <mono>stateflag</mono>, that is, whether the operation <mono>object->statusc & state->stateflag</mono> returns zero or not. If the result is true, then no state change is performed and the object continues to run as if nothing had happened. Certain scenarios imply some extra flags, for example certain events will check using the operation <mono>(object->statusc | 0x1002) & state->stateflag</mono> instead. <unknown>TBD</unknown>
 		</p>
 		<p>
 		In the code above, the object starts at state <mono>FirstState</mono>, and its flags are set appropriately. However, if the object now tries to change into state <mono>SecondState</mono>, it will fail to do so, because <mono>SecondState</mono>'s <mono>stateflag</mono> and the object's <mono>statusc</mono> both share the <mono>0x10</mono> flag. The object must remove the <mono>0x10</mono> flag from its <mono>statusc</mono> field in order for the change to be successful.

--- a/docs/html/state-trans.html
+++ b/docs/html/state-trans.html
@@ -39,7 +39,7 @@
 		Note that pre-subroutine modifiers are the only type of modifiers that can be used.
 		</p>
 		<p>
-		<mono>trans</mono> blocks have certain constructs that only makes sense to apply for them. Such constructs include the <mono>once</mono> statement. This statement everything after including and preceding its following block run only on the first execution of the trans block, after which the trans block pointer is moved to after the <mono>once</mono> statement. This is used to define variables that the state might use in the <mono>trans</mono> or <mono>code</mono> blocks, for example:
+		<mono>trans</mono> blocks have certain constructs that only makes sense to apply for them. Such constructs include the <mono>once</mono> statement. This statement, everything after, including, and preceding its following block run only on the first execution of the trans block, after which the trans block pointer is moved to after the <mono>once</mono> statement. This is used to define variables that the state might use in the <mono>trans</mono> or <mono>code</mono> blocks, for example:
 <code>trans {
     once {
         var0 = 1S // we are going to be using this field so we define it right away

--- a/docs/html/sub-params.html
+++ b/docs/html/sub-params.html
@@ -24,7 +24,7 @@
 		<h2>9.2. Subroutine Parameters</h2>
 		</span>
 		<p>
-		Function parameters can be any expression—a literal value, a value stored in variable, an address in memory, or a more complex expression built by combining these.
+		Function parameters can be any expression—a literal value, a value stored in a variable, an address in memory, or a more complex expression built by combining these.
 		</p>
 		<p>
 		From the callee's perspective, the (evaluated) parameter is a local copy of the value passed into the subroutine; you cannot change the value passed in by the caller by changing the local copy.

--- a/docs/html/token-constant.html
+++ b/docs/html/token-constant.html
@@ -12,8 +12,8 @@
 		</center>
 		<div style="font-size:125%;margin-top:0.25em;margin-bottom:0">
 		<div style="text-align:left;position:absolute;">
-		Previous: <a href="token-keyword.html">Keywords</a>,
 		Next: <a href="token-operator.html">Operators</a>,
+		Previous: <a href="token-keyword.html">Keywords</a>,
 		Up: <a href="lexer.html">Lexer Tokens</a>
 		</div>
 		<div style="text-align:right;">[<a href="../index.html">Contents</a>]</div>

--- a/docs/html/token-operator.html
+++ b/docs/html/token-operator.html
@@ -12,8 +12,8 @@
 		</center>
 		<div style="font-size:125%;margin-top:0.25em;margin-bottom:0">
 		<div style="text-align:left;position:absolute;">
-		Previous: <a href="token-constant.html">Constants</a>,
 		Next: <a href="token-separator.html">Separators</a>,
+		Previous: <a href="token-constant.html">Constants</a>,
 		Up: <a href="lexer.html">Lexer Tokens</a>
 		</div>
 		<div style="text-align:right;">[<a href="../index.html">Contents</a>]</div>


### PR DESCRIPTION
these have been bothering me